### PR TITLE
Make parsing and reading more explicit

### DIFF
--- a/blips.sh
+++ b/blips.sh
@@ -50,7 +50,7 @@ cd "$MEM_DIR" || exit
 install_implementations
 bind T T
 function rep() {
-expr=$(tokenise | create)
+    expr=$(read_s_expression)
     #echo expr=$expr
     result=$(eval_impl "$expr")
     #set -vx
@@ -62,18 +62,18 @@ expr=$(tokenise | create)
 
 function repl() {
     while true ; do
-        #echo -n '?:'
 	read -er -p '?: ' line
 	if [[ "$line" == '!exit' ]] ; then
 	    break
 	fi
-	expr=$(echo "$line" | tokenise | create )
+	expr=$(echo "$line" | read_s_expression )
 	result=$(eval_impl "$expr")
 	echo -n '='
 	print "$result"
 	echo ''
     done
 }
+
 repl
 
 

--- a/blips_functions.sh
+++ b/blips_functions.sh
@@ -125,8 +125,7 @@ function print_func_impl() {
 function load_func_impl() {
     if [[ $1 =~ \.str_.* ]] ; then
 	if [ -r "$CWD_DIR/$(cat "$1")" ] ; then
-	    #exprs=$(cat "$CWD_DIR/$(cat "$1")" | tokenise | tee debug.tmp | createlots )
-	    exprs=$(tokenise < "$CWD_DIR/$(cat "$1")" | tee debug.tmp | createlots )
+	    exprs=$(tokenise < "$CWD_DIR/$(cat "$1")" | parse_s_expressions )
 	    #echo exprs $exprs >&2
 	    for expr in $exprs ; do
 	        #echo evaluating $(print $expr) >&2
@@ -144,10 +143,10 @@ function load_func_impl() {
     fi 
 }
 
-function createlots() {
+function parse_s_expressions() {
     while true ; do
-	expr=$(create)
-	#echo createlots - next expr is $expr >&2
+	expr=$(parse_s_expression)
+	#echo parse_s_expressions - next expr is $expr >&2
 	if [[ $expr == EOF ]] ; then
 	    break
 	else

--- a/blips_read.sh
+++ b/blips_read.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-function create() {
+function parse_s_expression() {
     headcons=
     while true; do
 	if read -r line;  then
 	    if [[ "$line" == '(' ]]; then
-		next=$(create)
+		next=$(parse_s_expression)
 		while [[ $next != ')' ]] ; do
 		    if [[ $next == EOF ]] ; then
 			#echo EOF
@@ -21,7 +21,7 @@ function create() {
 		    prevcons=$nextcons
 		    mkdir "$nextcons"
 		    ln -s "../$next" "$nextcons/car"
-		    next=$(create)
+		    next=$(parse_s_expression)
 		done
 		if [[ $next == EOF ]] ; then
 		    break
@@ -94,6 +94,10 @@ function remove_blank_lines() {
 
 function tokenise() {
     remove_comments | strings_to_own_line |parens_to_own_line | tokens_to_own_line |remove_blank_lines
+}
+
+function read_s_expression() {
+    tokenise | parse_s_expression
 }
 
 


### PR DESCRIPTION
rename create to parse_s_expression

combine tokenize | create to be read_s_expression (making read
(as in REPL) more explicit)

rename createlots i(used to implement 'load') to
parse_s_expressions (plural).

Remove a few old commented out lines whose later
variabtions were modified.